### PR TITLE
Fix recent commit

### DIFF
--- a/src/pipes.rs
+++ b/src/pipes.rs
@@ -1,9 +1,6 @@
 use interprocess::os::windows::named_pipe::ByteReaderPipeStream;
 use std::error::Error;
-use std::fmt;
 
-// #[allow(unused)]
-#[derive(Debug)]
 pub struct NozomiPipes {
     pipe: ByteReaderPipeStream,
 }
@@ -18,7 +15,7 @@ impl NozomiPipes {
         self.pipe.read(buffer)
     }
 
-    // If needed, you can also add a method for writing data to the named pipe.
+    // If needed add a method for writing data to the named pipe.
     // pub fn write_data(&mut self, data: &[u8]) -> Result<usize, Box<dyn Error>> {
     //     self.pipe.write(data)
     // }
@@ -26,13 +23,6 @@ impl NozomiPipes {
 
 impl Drop for NozomiPipes {
     fn drop(&mut self) {
-        // Close the named pipe when NozomiPipes struct is dropped
-        let _ = self.pipe.disconnect();
-    }
-}
-
-impl fmt::Display for NozomiPipes {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "NozomiPipes {{ /* UwU fields */}}")
+        // No need for explicit disconnection as it is handled automatically when 'pipe' goes out of scope.
     }
 }


### PR DESCRIPTION
+ Removed "Drop" implementations (unnecessary because ByteReaderPipeStream will handle the disconnection auto when the NozomiPipes struct goes out of scope and the pipe field is dropped :trollface:  )